### PR TITLE
plumbing: add `HasEncodedObject` method to Storer

### DIFF
--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -36,6 +36,9 @@ type EncodedObjectStorer interface {
 	//
 	// Valid plumbing.ObjectType values are CommitObject, BlobObject, TagObject,
 	IterEncodedObjects(plumbing.ObjectType) (EncodedObjectIter, error)
+	// HasEncodedObject returns ErrObjNotFound if the object doesn't
+	// exist.  If the object does exist, it returns nil.
+	HasEncodedObject(plumbing.Hash) error
 }
 
 // DeltaObjectStorer is an EncodedObjectStorer that can return delta

--- a/plumbing/storer/object_test.go
+++ b/plumbing/storer/object_test.go
@@ -132,6 +132,15 @@ func (o *MockObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbi
 	return plumbing.ZeroHash, nil
 }
 
+func (o *MockObjectStorage) HasEncodedObject(h plumbing.Hash) error {
+	for _, o := range o.db {
+		if o.Hash() == h {
+			return nil
+		}
+	}
+	return plumbing.ErrObjectNotFound
+}
+
 func (o *MockObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	for _, o := range o.db {
 		if o.Hash() == h {

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -114,6 +114,14 @@ func (o *ObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.H
 	return h, nil
 }
 
+func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
+	_, ok := o.Objects[h]
+	if !ok {
+		return plumbing.ErrObjectNotFound
+	}
+	return nil
+}
+
 func (o *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, ok := o.Objects[h]
 	if !ok || (plumbing.AnyObject != t && obj.Type() != t) {


### PR DESCRIPTION
This allows the user to check whether an object exists, without
reading all the object data from storage.

Issue: KBFS-2445