### PR TITLE
filesystem: implement PackRefs()

### DIFF
--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -21,6 +21,8 @@ type ReferenceStorer interface {
 	IterReferences() (ReferenceIter, error)
 	RemoveReference(plumbing.ReferenceName) error
 	SetPackedRefs(refs []plumbing.Reference) error
+	CountLooseRefs() (int, error)
+	PackRefs() error
 }
 
 // ReferenceIter is a generic closable interface for iterating over references.

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -671,6 +671,10 @@ func (d *DotGit) CountLooseRefs() (int, error) {
 // TODO: before trying to get this merged upstream, move it into a
 // custom kbfsgit Storer implementation, and rewrite this function to
 // work correctly on a general filesystem.
+//
+// TODO: add an "all" boolean like the `git pack-refs --all` flag.
+// When `all` is false, it would only pack refs that have already been
+// packed, plus all tags.
 func (d *DotGit) PackRefs() (err error) {
 	// Lock packed-refs, and create it if it doesn't exist yet.
 	f, err := d.fs.Open(packedRefsPath)

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -639,6 +639,121 @@ func (d *DotGit) SetPackedRefs(refs []plumbing.Reference) (err error) {
 	return nil
 }
 
+func (d *DotGit) CountLooseRefs() (int, error) {
+	var refs []*plumbing.Reference
+	var seen = make(map[plumbing.ReferenceName]bool)
+	if err := d.addRefsFromRefDir(&refs, seen); err != nil {
+		return 0, err
+	}
+
+	return len(refs), nil
+}
+
+// PackRefs packs all loose refs into the packed-refs file.
+//
+// This implementation only works under the assumption that the view
+// of the file system won't be updated during this operation, which is
+// true for kbfsgit after the Lock() operation is complete (and before
+// the Unlock()/Close() of the locked file).  If another process
+// concurrently updates one of the loose refs we delete, then KBFS
+// conflict resolution would just end up ignoring our delete.  Also
+// note that deleting a ref requires locking packed-refs, so a ref
+// deleted by the user shouldn't be revived by ref-packing.
+//
+// The strategy would not work on a general file system though,
+// without locking each loose reference and checking it again before
+// deleting the file, because otherwise an updated reference could
+// sneak in and then be deleted by the packed-refs process.
+// Alternatively, every ref update could also lock packed-refs, so
+// only one lock is required during ref-packing.  But that would
+// worsen performance in the common case.
+//
+// TODO: before trying to get this merged upstream, move it into a
+// custom kbfsgit Storer implementation, and rewrite this function to
+// work correctly on a general filesystem.
+func (d *DotGit) PackRefs() (err error) {
+	// Lock packed-refs, and create it if it doesn't exist yet.
+	f, err := d.fs.Open(packedRefsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			f, err = d.fs.Create(packedRefsPath)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	defer ioutil.CheckClose(f, &err)
+
+	err = f.Lock()
+	if err != nil {
+		return err
+	}
+
+	// Gather all refs using addRefsFromRefDir and addRefsFromPackedRefs.
+	var refs []*plumbing.Reference
+	var seen = make(map[plumbing.ReferenceName]bool)
+	if err := d.addRefsFromRefDir(&refs, seen); err != nil {
+		return err
+	}
+	if len(refs) == 0 {
+		// Nothing to do!
+		return nil
+	}
+	numLooseRefs := len(refs)
+	if err := d.addRefsFromPackedRefs(&refs, seen); err != nil {
+		return err
+	}
+
+	// Write them all to a new temp packed-refs file.
+	tmp, err := d.fs.TempFile("", tmpPackedRefsPrefix)
+	if err != nil {
+		return err
+	}
+	doCloseTmp := true
+	defer func() {
+		if doCloseTmp {
+			ioutil.CheckClose(tmp, &err)
+		}
+	}()
+	for _, ref := range refs {
+		_, err := tmp.Write([]byte(ref.String() + "\n"))
+		if err != nil {
+			return err
+		}
+	}
+
+	// Rename the temp packed-refs file.
+	doCloseTmp = false
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	err = d.fs.Rename(tmp.Name(), packedRefsPath)
+	if err != nil {
+		return err
+	}
+
+	// Delete all the loose refs, while still holding the packed-refs
+	// lock.
+	for _, ref := range refs[:numLooseRefs] {
+		path := d.fs.Join(".", ref.Name().String())
+		err = d.fs.Remove(path)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	// Update packed-refs cache.
+	d.cachedPackedRefs = make(refCache)
+	for _, ref := range refs {
+		d.cachedPackedRefs[ref.Name()] = ref
+	}
+	d.packedRefsLastMod = time.Now()
+
+	return nil
+}
+
 // Module return a billy.Filesystem poiting to the module folder
 func (d *DotGit) Module(name string) (billy.Filesystem, error) {
 	return d.fs.Chroot(d.fs.Join(modulePath, name))

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -445,17 +445,29 @@ func (d *DotGit) rewritePackedRefsWithoutRef(name plumbing.ReferenceName) (err e
 
 		return err
 	}
-	doCloseF := true
-	defer func() {
-		if doCloseF {
-			ioutil.CheckClose(f, &err)
-		}
-	}()
+	defer ioutil.CheckClose(f, &err)
 
 	err = f.Lock()
 	if err != nil {
 		return err
 	}
+
+	// Re-open the file after locking, since it could have been
+	// renamed over by a new file during the Lock process.
+	pr, err := d.fs.Open(packedRefsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+	doClosePR := true
+	defer func() {
+		if doClosePR {
+			ioutil.CheckClose(pr, &err)
+		}
+	}()
 
 	// Creating the temp file in the same directory as the target file
 	// improves our chances for rename operation to be atomic.
@@ -470,7 +482,7 @@ func (d *DotGit) rewritePackedRefsWithoutRef(name plumbing.ReferenceName) (err e
 		}
 	}()
 
-	s := bufio.NewScanner(f)
+	s := bufio.NewScanner(pr)
 	found := false
 	for s.Scan() {
 		line := s.Text()
@@ -503,8 +515,8 @@ func (d *DotGit) rewritePackedRefsWithoutRef(name plumbing.ReferenceName) (err e
 		return d.fs.Remove(tmp.Name())
 	}
 
-	doCloseF = false
-	if err := f.Close(); err != nil {
+	doClosePR = false
+	if err := pr.Close(); err != nil {
 		return err
 	}
 

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -642,13 +642,14 @@ func (d *DotGit) SetPackedRefs(refs []plumbing.Reference) (err error) {
 		return errors.New("packed-refs file already initialized")
 	}
 
+	w := bufio.NewWriter(f)
 	for _, ref := range refs {
-		_, err := f.Write([]byte(ref.String() + "\n"))
+		_, err := w.WriteString(ref.String() + "\n")
 		if err != nil {
 			return err
 		}
 	}
-	return nil
+	return w.Flush()
 }
 
 func (d *DotGit) CountLooseRefs() (int, error) {
@@ -689,16 +690,9 @@ func (d *DotGit) CountLooseRefs() (int, error) {
 // packed, plus all tags.
 func (d *DotGit) PackRefs() (err error) {
 	// Lock packed-refs, and create it if it doesn't exist yet.
-	f, err := d.fs.Open(packedRefsPath)
+	f, err := d.fs.OpenFile(packedRefsPath, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
-		if os.IsNotExist(err) {
-			f, err = d.fs.Create(packedRefsPath)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
+		return err
 	}
 	defer ioutil.CheckClose(f, &err)
 
@@ -733,11 +727,16 @@ func (d *DotGit) PackRefs() (err error) {
 			ioutil.CheckClose(tmp, &err)
 		}
 	}()
+	w := bufio.NewWriter(tmp)
 	for _, ref := range refs {
-		_, err := tmp.Write([]byte(ref.String() + "\n"))
+		_, err := w.WriteString(ref.String() + "\n")
 		if err != nil {
 			return err
 		}
+	}
+	err = w.Flush()
+	if err != nil {
+		return err
 	}
 
 	// Rename the temp packed-refs file.

--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -487,3 +487,75 @@ func (s *SuiteDotGit) TestSubmodules(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(strings.HasSuffix(m.Root(), m.Join(".git", "modules", "basic")), Equals, true)
 }
+
+func (s *SuiteDotGit) TestPackRefs(c *C) {
+	tmp, err := ioutil.TempDir("", "dot-git")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmp)
+
+	fs := osfs.New(tmp)
+	dir := New(fs)
+
+	err = dir.SetRef(plumbing.NewReferenceFromStrings(
+		"refs/heads/foo",
+		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
+	), nil)
+	c.Assert(err, IsNil)
+	err = dir.SetRef(plumbing.NewReferenceFromStrings(
+		"refs/heads/bar",
+		"a8d3ffab552895c19b9fcf7aa264d277cde33881",
+	), nil)
+	c.Assert(err, IsNil)
+
+	refs, err := dir.Refs()
+	c.Assert(err, IsNil)
+	c.Assert(refs, HasLen, 2)
+	looseCount, err := dir.CountLooseRefs()
+	c.Assert(err, IsNil)
+	c.Assert(looseCount, Equals, 2)
+
+	err = dir.PackRefs()
+	c.Assert(err, IsNil)
+
+	// Make sure the refs are still there, but no longer loose.
+	refs, err = dir.Refs()
+	c.Assert(err, IsNil)
+	c.Assert(refs, HasLen, 2)
+	looseCount, err = dir.CountLooseRefs()
+	c.Assert(err, IsNil)
+	c.Assert(looseCount, Equals, 0)
+
+	ref, err := dir.Ref("refs/heads/foo")
+	c.Assert(err, IsNil)
+	c.Assert(ref, NotNil)
+	c.Assert(ref.Hash().String(), Equals, "e8d3ffab552895c19b9fcf7aa264d277cde33881")
+	ref, err = dir.Ref("refs/heads/bar")
+	c.Assert(err, IsNil)
+	c.Assert(ref, NotNil)
+	c.Assert(ref.Hash().String(), Equals, "a8d3ffab552895c19b9fcf7aa264d277cde33881")
+
+	// Now update one of them, re-pack, and check again.
+	err = dir.SetRef(plumbing.NewReferenceFromStrings(
+		"refs/heads/foo",
+		"b8d3ffab552895c19b9fcf7aa264d277cde33881",
+	), nil)
+	c.Assert(err, IsNil)
+	looseCount, err = dir.CountLooseRefs()
+	c.Assert(err, IsNil)
+	c.Assert(looseCount, Equals, 1)
+	err = dir.PackRefs()
+	c.Assert(err, IsNil)
+
+	// Make sure the refs are still there, but no longer loose.
+	refs, err = dir.Refs()
+	c.Assert(err, IsNil)
+	c.Assert(refs, HasLen, 2)
+	looseCount, err = dir.CountLooseRefs()
+	c.Assert(err, IsNil)
+	c.Assert(looseCount, Equals, 0)
+
+	ref, err = dir.Ref("refs/heads/foo")
+	c.Assert(err, IsNil)
+	c.Assert(ref, NotNil)
+	c.Assert(ref.Hash().String(), Equals, "b8d3ffab552895c19b9fcf7aa264d277cde33881")
+}

--- a/storage/filesystem/reference.go
+++ b/storage/filesystem/reference.go
@@ -38,3 +38,11 @@ func (r *ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 func (r *ReferenceStorage) SetPackedRefs(refs []plumbing.Reference) error {
 	return r.dir.SetPackedRefs(refs)
 }
+
+func (r *ReferenceStorage) CountLooseRefs() (int, error) {
+	return r.dir.CountLooseRefs()
+}
+
+func (r *ReferenceStorage) PackRefs() error {
+	return r.dir.PackRefs()
+}

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -254,6 +254,14 @@ func (r ReferenceStorage) SetPackedRefs(refs []plumbing.Reference) error {
 	return nil
 }
 
+func (r ReferenceStorage) CountLooseRefs() (int, error) {
+	return len(r), nil
+}
+
+func (r ReferenceStorage) PackRefs() error {
+	return nil
+}
+
 func (r ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 	delete(r, n)
 	return nil


### PR DESCRIPTION
Currently this implementation is only valid for kbfsgit, since it assumes some things about the filesystem not being updated during the packing, and about conflict resolution rules.  In the future, it would be nice to replace this with a more general one, and move this kbfsgit-optimized implementation into kbfsgit.

Issue: KBFS-2517