### PR TITLE
Object repacking 2

### DIFF
--- a/object_walker.go
+++ b/object_walker.go
@@ -1,0 +1,105 @@
+package git
+
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/storage"
+)
+
+type objectWalker struct {
+	Storer storage.Storer
+	// seen is the set of objects seen in the repo.
+	// seen map can become huge if walking over large
+	// repos. Thus using struct{} as the value type.
+	seen map[plumbing.Hash]struct{}
+}
+
+func newObjectWalker(s storage.Storer) *objectWalker {
+	return &objectWalker{s, map[plumbing.Hash]struct{}{}}
+}
+
+// walkAllRefs walks all (hash) refererences from the repo.
+func (p *objectWalker) walkAllRefs() error {
+	// Walk over all the references in the repo.
+	it, err := p.Storer.IterReferences()
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+	err = it.ForEach(func(ref *plumbing.Reference) error {
+		// Exit this iteration early for non-hash references.
+		if ref.Type() != plumbing.HashReference {
+			return nil
+		}
+		return p.walkObjectTree(ref.Hash())
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *objectWalker) isSeen(hash plumbing.Hash) bool {
+	_, seen := p.seen[hash]
+	return seen
+}
+
+func (p *objectWalker) add(hash plumbing.Hash) {
+	p.seen[hash] = struct{}{}
+}
+
+// walkObjectTree walks over all objects and remembers references
+// to them in the objectWalker. This is used instead of the revlist
+// walks because memory usage is tight with huge repos.
+func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
+	// Check if we have already seen, and mark this object
+	if p.isSeen(hash) {
+		return nil
+	}
+	p.add(hash)
+	// Fetch the object.
+	obj, err := object.GetObject(p.Storer, hash)
+	if err != nil {
+		return fmt.Errorf("Getting object %s failed: %v", hash, err)
+	}
+	// Walk all children depending on object type.
+	switch obj := obj.(type) {
+	case *object.Commit:
+		err = p.walkObjectTree(obj.TreeHash)
+		if err != nil {
+			return err
+		}
+		for _, h := range obj.ParentHashes {
+			err = p.walkObjectTree(h)
+			if err != nil {
+				return err
+			}
+		}
+	case *object.Tree:
+		for i := range obj.Entries {
+			// Shortcut for blob objects:
+			// 'or' the lower bits of a mode and check that it
+			// it matches a filemode.Executable. The type information
+			// is in the higher bits, but this is the cleanest way
+			// to handle plain files with different modes.
+			// Other non-tree objects are somewhat rare, so they
+			// are not special-cased.
+			if obj.Entries[i].Mode|0755 == filemode.Executable {
+				p.add(obj.Entries[i].Hash)
+				continue
+			}
+			// Normal walk for sub-trees (and symlinks etc).
+			err = p.walkObjectTree(obj.Entries[i].Hash)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		// Error out on unhandled object types.
+		return fmt.Errorf("Unknown object %X %s %T\n", obj.ID(), obj.Type(), obj)
+	}
+	return nil
+}

--- a/prune.go
+++ b/prune.go
@@ -1,13 +1,9 @@
 package git
 
 import (
-	"fmt"
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
-	"gopkg.in/src-d/go-git.v4/storage"
 )
 
 type PruneHandler func(unreferencedObjectHash plumbing.Hash) error
@@ -26,23 +22,8 @@ func (r *Repository) DeleteObject(hash plumbing.Hash) error {
 }
 
 func (r *Repository) Prune(opt PruneOptions) error {
-	pw := &pruneWalker{
-		Storer: r.Storer,
-		seen:   map[plumbing.Hash]struct{}{},
-	}
-	// Walk over all the references in the repo.
-	it, err := r.Storer.IterReferences()
-	if err != nil {
-		return nil
-	}
-	defer it.Close()
-	err = it.ForEach(func(ref *plumbing.Reference) error {
-		// Exit this iteration early for non-hash references.
-		if ref.Type() != plumbing.HashReference {
-			return nil
-		}
-		return pw.walkObjectTree(ref.Hash())
-	})
+	pw := newObjectWalker(r.Storer)
+	err := pw.walkAllRefs()
 	if err != nil {
 		return err
 	}
@@ -70,76 +51,6 @@ func (r *Repository) Prune(opt PruneOptions) error {
 	})
 	if err != nil {
 		return err
-	}
-	return nil
-}
-
-type pruneWalker struct {
-	Storer storage.Storer
-	// seen is the set of objects seen in the repo.
-	// seen map can become huge if walking over large
-	// repos. Thus using struct{} as the value type.
-	seen map[plumbing.Hash]struct{}
-}
-
-func (p *pruneWalker) isSeen(hash plumbing.Hash) bool {
-	_, seen := p.seen[hash]
-	return seen
-}
-
-func (p *pruneWalker) add(hash plumbing.Hash) {
-	p.seen[hash] = struct{}{}
-}
-
-// walkObjectTree walks over all objects and remembers references
-// to them in the pruneWalker. This is used instead of the revlist
-// walks because memory usage is tight with huge repos.
-func (p *pruneWalker) walkObjectTree(hash plumbing.Hash) error {
-	// Check if we have already seen, and mark this object
-	if p.isSeen(hash) {
-		return nil
-	}
-	p.add(hash)
-	// Fetch the object.
-	obj, err := object.GetObject(p.Storer, hash)
-	if err != nil {
-		return fmt.Errorf("Getting object %s failed: %v", hash, err)
-	}
-	// Walk all children depending on object type.
-	switch obj := obj.(type) {
-	case *object.Commit:
-		err = p.walkObjectTree(obj.TreeHash)
-		if err != nil {
-			return err
-		}
-		for _, h := range obj.ParentHashes {
-			err = p.walkObjectTree(h)
-			if err != nil {
-				return err
-			}
-		}
-	case *object.Tree:
-		for i := range obj.Entries {
-			// Shortcut for blob objects:
-			// 'or' the lower bits of a mode and check that it
-			// it matches a filemode.Executable. The type information
-			// is in the higher bits, but this is the cleanest way
-			// to handle plain files with different modes.
-			// Other non-tree objects are somewhat rare, so they
-			// are not special-cased.
-			if obj.Entries[i].Mode|0755 == filemode.Executable {
-				p.add(obj.Entries[i].Hash)
-				continue
-			}
-			// Normal walk for sub-trees (and symlinks etc).
-			err = p.walkObjectTree(obj.Entries[i].Hash)
-			if err != nil {
-				return err
-			}
-		}
-	default:
-		// Error out on unhandled object types.
-		return fmt.Errorf("Unknown object %X %s %T\n", obj.ID(), obj.Type(), obj)
 	}
 	return nil
 }

--- a/repository.go
+++ b/repository.go
@@ -1020,8 +1020,6 @@ type RepackConfig struct {
 	// UseRefDeltas configures whether packfile encoder will use reference deltas.
 	// By default OFSDeltaObject is used.
 	UseRefDeltas bool
-	// PackWindow for packing objects.
-	PackWindow uint
 	// OnlyDeletePacksOlderThan if set to non-zero value
 	// selects only objects older than the time provided.
 	OnlyDeletePacksOlderThan time.Time
@@ -1080,8 +1078,12 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 	if err != nil {
 		return h, err
 	}
+	scfg, err := r.Storer.Config()
+	if err != nil {
+		return h, err
+	}
 	enc := packfile.NewEncoder(wc, r.Storer, cfg.UseRefDeltas)
-	h, err = enc.Encode(objs, cfg.PackWindow, cfg.StatusChan)
+	h, err = enc.Encode(objs, scfg.Pack.Window, cfg.StatusChan)
 	if err != nil {
 		return h, err
 	}

--- a/repository.go
+++ b/repository.go
@@ -1057,6 +1057,15 @@ func (r *Repository) RepackObjects(cfg *RepackConfig) (err error) {
 // of creating a new pack. It is used so the the PackfileWriter
 // deferred close has the right scope.
 func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, err error) {
+	ow := newObjectWalker(r.Storer)
+	err = ow.walkAllRefs()
+	if err != nil {
+		return h, err
+	}
+	objs := make([]plumbing.Hash, 0, len(ow.seen))
+	for h := range ow.seen {
+		objs = append(objs, h)
+	}
 	pfw, ok := r.Storer.(storer.PackfileWriter)
 	if !ok {
 		return h, fmt.Errorf("Repository storer is not a storer.PackfileWriter")
@@ -1066,18 +1075,6 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 		return h, err
 	}
 	defer ioutil.CheckClose(wc, &err)
-	var objs []plumbing.Hash
-	iter, err := r.Storer.IterEncodedObjects(plumbing.AnyObject)
-	if err != nil {
-		return h, err
-	}
-	err = iter.ForEach(func(obj plumbing.EncodedObject) error {
-		objs = append(objs, obj.Hash())
-		return nil
-	})
-	if err != nil {
-		return h, err
-	}
 	scfg, err := r.Storer.Config()
 	if err != nil {
 		return h, err


### PR DESCRIPTION
Addresses comments in https://github.com/keybase/go-git/pull/15 after the merge.

+ Use Storer.Config for pack window
+ For walking the objects reuse the prune object walking code to avoid repacking orphan objects inside old object packs.