### PR TITLE
dotgit: ignore filenames that don't match a hash

### DIFF
--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -160,8 +160,11 @@ func (d *DotGit) ObjectPacks() ([]plumbing.Hash, error) {
 
 		n := f.Name()
 		h := plumbing.NewHash(n[5 : len(n)-5]) //pack-(hash).pack
+		if h.IsZero() {
+			// Ignore files with badly-formatted names.
+			continue
+		}
 		packs = append(packs, h)
-
 	}
 
 	return packs, nil
@@ -257,7 +260,12 @@ func (d *DotGit) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 			}
 
 			for _, o := range d {
-				err = fun(plumbing.NewHash(base + o.Name()))
+				h := plumbing.NewHash(base + o.Name())
+				if h.IsZero() {
+					// Ignore files with badly-formatted names.
+					continue
+				}
+				err = fun(h)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
For both packfiles and object files.

Issue: keybase/client#11366