### PR TITLE
Plumb statusChan through with the new fetch code

### DIFF
--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -31,7 +31,7 @@ func UpdateObjectStorage(s storer.Storer, packfile io.Reader, statusChan plumbin
 		return WritePackfileToObjectStorage(pw, packfile, statusChan)
 	}
 
-	p, err := NewParserWithStorage(NewScanner(packfile), s)
+	p, err := NewParserWithStorage(NewScanner(packfile), s, NewStatusObserver(statusChan))
 	if err != nil {
 		return err
 	}

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -35,6 +35,33 @@ type Observer interface {
 	OnFooter(h plumbing.Hash) error
 }
 
+type StatusObserver struct {
+	statusChan plumbing.StatusChan
+	update     plumbing.StatusUpdate
+}
+
+func NewStatusObserver(sc plumbing.StatusChan) *StatusObserver {
+	return &StatusObserver{statusChan: sc}
+}
+func (so *StatusObserver) OnHeader(count uint32) error {
+	so.update.Stage = plumbing.StatusFetch
+	so.update.ObjectsTotal = int(count)
+	so.statusChan.SendUpdate(so.update)
+
+	return nil
+}
+func (so *StatusObserver) OnInflatedObjectHeader(t plumbing.ObjectType, objSize int64, pos int64) error {
+	so.statusChan.SendUpdate(so.update)
+	so.update.ObjectsDone++
+	return nil
+}
+func (so *StatusObserver) OnInflatedObjectContent(plumbing.Hash, int64, uint32, []byte) error {
+	return nil
+}
+func (so *StatusObserver) OnFooter(plumbing.Hash) error {
+	return nil
+}
+
 // Parser decodes a packfile and calls any observer associated to it. Is used
 // to generate indexes.
 type Parser struct {

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -59,6 +59,7 @@ func (so *StatusObserver) OnInflatedObjectContent(plumbing.Hash, int64, uint32, 
 	return nil
 }
 func (so *StatusObserver) OnFooter(plumbing.Hash) error {
+	so.statusChan.SendUpdate(so.update)
 	return nil
 }
 

--- a/storage/filesystem/dotgit/writers.go
+++ b/storage/filesystem/dotgit/writers.go
@@ -60,7 +60,7 @@ func (w *PackWriter) buildIndex() {
 	s := packfile.NewScanner(w.synced)
 	w.writer = new(idxfile.Writer)
 	var err error
-	w.parser, err = packfile.NewParser(s, w.writer)
+	w.parser, err = packfile.NewParser(s, w.writer, packfile.NewStatusObserver(w.statusChan))
 	if err != nil {
 		w.result <- err
 		return


### PR DESCRIPTION
New fetching code was not updating statusChans properly.

This caused kbfsgit not to display status progress for the fetch part when uploading.

go test ./... passes as usual.